### PR TITLE
PATH fix for MacOS

### DIFF
--- a/utils/_common.sh
+++ b/utils/_common.sh
@@ -10,6 +10,9 @@ export GOAL_CMD="./goal.sh"
 
 export DOCKER_CLI_HINTS=false
 
+# auto-update does not work on Mac without this
+export PATH="$PATH:/usr/local/bin:/opt/homebrew/bin"
+
 function confirm_requirements {
   # check that requirements are installed
   # override default list by calling with arguments


### PR DESCRIPTION
Addressing issue of incomplete PATH during crontabbed `auto-update.sh` on MacOS