### PR TITLE
README: clarify entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,25 @@
 
 ## Overview
 
-A set of scripts to configure and run a dockerized algod for [fnet](https://fnet.algorand.green/).
+A set of scripts to configure and run a dockerized algod for [FNet](https://fnet.algorand.green/).
 
-**Entry point: `./run.sh`**. Run this to configure and start your container.
+## Getting Started
 
-The Fnet network will be reset periodically. The scripts support automatically resetting the node to follow along with the new network.
+Use the `run` script to configure and launch an FNet node
+
+```
+./run.sh
+```
+
+## Automatic Updates 
+
+To update your node automatically, set up a cron job to execute `auto-update.sh`
+
+The Fnet network may be reset. The scripts support automatically resetting the node to follow along with the new network.
 
 The `on-network-reset.sh` script can also be utilized to bootstrap some user actions when a new instance of the network is created, such as keyreg online, create applications, fund other addresses, etc.
+
+## KMD & Participation keys
 
 A default passwordless KMD will be available in the container. Accounts you import **will** be persisted when you reset the network data dir (through `utils/reset.sh`)
 
@@ -30,13 +42,11 @@ These scripts are to be run on your **host** machine.
 
 ## Utilities
 
-Two important utilities you may want to use:
+These scripts are to be run on your **host** machine.
 
 `./utils/shell.sh` starts a shell in the docker container
 
 `./utils/reset.sh` clears local algod data and genesis file and restarts the node. Does not reset KMD data. This is required if genesis has changed since you last ran your node.
-
-### Minor
 
 `./utils/catchup.sh` Starts fast catchup, waits for sync.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Participation keyfiles (.partkey) can be generated standalone using `utils/algok
 
 ## Table of Contents
 
+These scripts are to be run on your **host** machine.
+
 `./run.sh` **Entry point.** Configures a local docker algod instance and starts it
 
 `./stop.sh` stops the docker instance

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A set of scripts to configure and run a dockerized algod for [fnet](https://fnet.algorand.green/).
 
+**Entry point: `./run.sh`**. Run this to configure and start your container.
+
 The Fnet network will be reset periodically. The scripts support automatically resetting the node to follow along with the new network.
 
 The `on-network-reset.sh` script can also be utilized to bootstrap some user actions when a new instance of the network is created, such as keyreg online, create applications, fund other addresses, etc.
@@ -16,7 +18,7 @@ Participation keyfiles (.partkey) can be generated standalone using `utils/algok
 
 ## Table of Contents
 
-`./run.sh` configures a local docker algod instance and starts it
+`./run.sh` **Entry point.** Configures a local docker algod instance and starts it
 
 `./stop.sh` stops the docker instance
 


### PR DESCRIPTION
Clarification that `run.sh` is required to configure the docker image.